### PR TITLE
Mirror of dropbox dropbox-sdk-java#70

### DIFF
--- a/src/main/java/com/dropbox/core/http/OkHttp3Requestor.java
+++ b/src/main/java/com/dropbox/core/http/OkHttp3Requestor.java
@@ -86,13 +86,10 @@ public class OkHttp3Requestor extends HttpRequestor {
     }
 
     /**
-     * Returns the underlying {@code OkHttpClient} used to make requests.
-     *
-     * If you want to modify the client for a particular request, create a new instance of this
-     * requestor with the modified client.
-     *
-     * @return underlying {@code OkHttpClient} used by this requestor.
+     * @deprecated If you need access to the {@link OkHttpClient} instance you passed
+     *     into the constructor, keep track of it yourself.
      */
+    @Deprecated
     public OkHttpClient getClient() {
         return client;
     }

--- a/src/main/java/com/dropbox/core/http/OkHttpRequestor.java
+++ b/src/main/java/com/dropbox/core/http/OkHttpRequestor.java
@@ -76,13 +76,10 @@ public class OkHttpRequestor extends HttpRequestor {
     }
 
     /**
-     * Returns a clone of the underlying {@code OkHttpClient} used to make requests.
-     *
-     * If you want to modify the client for a particular request, create a new instance of this
-     * requestor with the modified client.
-     *
-     * @return clone of the underlying {@code OkHttpClient} used by this requestor.
+     * @deprecated If you need access to the {@link OkHttpClient} instance you passed
+     *     into the constructor, keep track of it yourself.
      */
+    @Deprecated
     public OkHttpClient getClient() {
         return client;
     }


### PR DESCRIPTION
Mirror of dropbox dropbox-sdk-java#70
It seems like an unnecessary API.  If you want access to that client,
just keep it around instead of keeping around the HttpRequestor wrapper.

@zjiuyang 

